### PR TITLE
Add Squad setup skill and update first-time-setup prompt

### DIFF
--- a/base/.github/copilot/skills/squad-setup/SKILL.md
+++ b/base/.github/copilot/skills/squad-setup/SKILL.md
@@ -1,0 +1,94 @@
+# Squad Setup
+
+How to install and initialise [Squad](https://github.com/bradygaster/squad) in a new project.
+
+> **Squad is alpha software** — installation steps may change between releases.
+> Before following this guide, fetch the current README from `https://github.com/bradygaster/squad`
+> (use the `fetch_webpage` tool or Microsoft Learn MCP) and verify the steps below still match.
+> If they differ, follow the upstream README and flag the discrepancy to the user.
+
+## Prerequisites
+
+| Requirement | Minimum | Check |
+|-------------|---------|-------|
+| Node.js | 22.5.0+ | `node --version` |
+| Git | Any | `git status` (must be inside a git repo) |
+| GitHub CLI | Any | `gh auth status` (must be authenticated) |
+
+## Installation
+
+### Option A — Global install (recommended for regular use)
+
+```bash
+npm install -g @bradygaster/squad-cli
+```
+
+### Option B — One-shot via npx (no global install)
+
+```bash
+npx @bradygaster/squad-cli
+```
+
+After global install, verify:
+
+```bash
+squad --version
+```
+
+## Initialise Squad in the project
+
+```bash
+squad init
+```
+
+This scaffolds the `.squad/` directory with:
+
+- `team.md` — team roster
+- `routing.md` — message routing rules
+- `decisions.md` — shared decision log
+- `agents/` — individual agent charters and history
+- `skills/` — team-learned skills (grows over time)
+
+## Verify setup
+
+```bash
+squad doctor
+```
+
+This checks prerequisites, file structure, and GitHub connectivity.
+
+## Usage in VS Code
+
+Open Copilot Chat and select the Squad agent (`@squad`). Start with:
+
+```
+I'm starting a new project. Set up the team.
+Here's what I'm building: <describe your project>
+```
+
+Squad will propose a team of specialists. Confirm to begin.
+
+## Upgrading
+
+```bash
+npm install -g @bradygaster/squad-cli@latest
+squad upgrade
+```
+
+`squad upgrade` updates Squad-owned files to the latest version without touching your team state.
+
+## Key commands
+
+| Command | Purpose |
+|---------|---------|
+| `squad init` | Scaffold Squad in current directory (idempotent) |
+| `squad doctor` | Check setup and diagnose issues |
+| `squad upgrade` | Update Squad files to latest |
+| `squad status` | Show active squad and configuration |
+| `squad copilot` | Add/remove the Copilot coding agent |
+
+## Reference
+
+- **Repository**: https://github.com/bradygaster/squad
+- **Documentation**: https://bradygaster.github.io/squad/
+- **npm package**: `@bradygaster/squad-cli`

--- a/base/.github/prompts/first-time-setup.prompt.md
+++ b/base/.github/prompts/first-time-setup.prompt.md
@@ -55,9 +55,19 @@ If this is a fresh clone from "Use this template":
 - Verify git is initialised (`git status`)
 - If the user provided a GitHub repo URL, verify or set the remote
 
-## Step 6 — Check Squad Availability
+## Step 6 — Install or Verify Squad
 
-Look for Squad's agent file (typically `.github/agents/squad.agent.md` or similar location set by Squad installation). If found, report the version. If not found, note that Squad can be installed via npm.
+Check if Squad is already installed by looking for its agent file (typically `.github/agents/squad.agent.md` or `.squad/team.md`).
+
+**If Squad is found:**
+- Report the installed version (`squad --version` if available)
+- Run `squad doctor` to confirm everything is healthy
+
+**If Squad is NOT found (expected for new repos):**
+- Read the `squad-setup` skill for installation and initialisation steps
+- Before proceeding, fetch the current Squad README from `https://github.com/bradygaster/squad` and verify the skill's steps are still accurate (Squad is alpha software and the process may change)
+- Walk the user through installation and `squad init`
+- Run `squad doctor` to verify setup
 
 ## Step 7 — Summary and Next Steps
 


### PR DESCRIPTION
Fixes #2

## Problem

Step 6 of the first-time-setup prompt checks for Squad availability but provides no guidance on how to install or initialise it — which is the expected state for a freshly created repo.

## Changes

### New: `base/.github/copilot/skills/squad-setup/SKILL.md`
- Installation methods: global install (`npm install -g @bradygaster/squad-cli`) or npx
- `squad init` to scaffold `.squad/` in the project
- Prerequisites (Node 22.5.0+, git repo, `gh auth login`)
- `squad doctor` to verify setup
- Upgrading instructions
- Key commands reference table
- **Runtime verification**: instructs the agent to fetch the upstream README at `https://github.com/bradygaster/squad` before following the guide, since Squad is alpha and the process may change

### Updated: `base/.github/prompts/first-time-setup.prompt.md`
- Step 6 now branches on whether Squad is found:
  - **Found**: report version, run `squad doctor`
  - **Not found**: read the `squad-setup` skill, verify against upstream README, walk through installation