### PR TITLE
Fix: force-update tags on downstream repos

### DIFF
--- a/.github/workflows/compose-and-publish.yml
+++ b/.github/workflows/compose-and-publish.yml
@@ -59,5 +59,5 @@ jobs:
       - name: Tag template repo
         working-directory: target-repo
         run: |
-          git tag "${{ github.ref_name }}"
-          git push origin "${{ github.ref_name }}"
+          git tag -f "${{ github.ref_name }}"
+          git push origin "${{ github.ref_name }}" --force


### PR DESCRIPTION
The compose-and-publish workflow fails when re-tagging downstream repos (e.g. after a history rewrite). The tag step now uses `git tag -f` and `git push --force` to handle existing tags gracefully.