### PR TITLE
Restrict compose-and-publish to tags on main

### DIFF
--- a/.github/workflows/compose-and-publish.yml
+++ b/.github/workflows/compose-and-publish.yml
@@ -9,7 +9,26 @@ permissions:
   contents: read
 
 jobs:
+  guard:
+    runs-on: ubuntu-latest
+    outputs:
+      on-main: ${{ steps.check.outputs.on-main }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - id: check
+        run: |
+          if git branch -r --contains "${{ github.sha }}" | grep -q 'origin/main'; then
+            echo "on-main=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::Tag ${{ github.ref_name }} does not point to a commit on main — skipping publish."
+            echo "on-main=false" >> "$GITHUB_OUTPUT"
+          fi
+
   compose-and-publish:
+    needs: guard
+    if: needs.guard.outputs.on-main == 'true'
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Adds a guard job that verifies the tagged commit is reachable from `origin/main` before running the compose-and-publish matrix. Tags pushed on other branches (e.g. `dev`) are skipped with a warning annotation.