### PR TITLE
docs: sync squad history and decision record to main

### DIFF
--- a/.squad/agents/amos/history.md
+++ b/.squad/agents/amos/history.md
@@ -193,3 +193,12 @@ Implemented CLI template onboarding: added to templates.json, updated workspace 
     - **Orchestration log created:** 2026-04-14T20:29:04Z-amos.md documents end-to-end execution.
     - **Note:** Post-release, minor stale wording identified in already-published CLI README; source docs corrected on dev by Naomi (follow-up doc cleanup pending dev push).
     - **Outcome:** v0.5.0 successfully released; all infrastructure and composition performed as designed.
+
+- Session 20 (2026-04-14): Post-v0.5.0 branch sync — dev → main cleanup.
+    - **Cleanup:** Removed 11 untracked enabled Squad workflow files (`.yml` copies left by Squad update). `.disabled` variants remain authoritative.
+    - **Branch sync:** Merged `origin/main` into `dev` to incorporate v0.5.0 merge commit, then pushed dev.
+    - **PR #31 opened and merged:** `dev → main`, docs-only sync (agent histories, decision records, release doc fixes, now.md update).
+    - **Fast-forward:** After merge, fast-forwarded dev to main's new HEAD — branches fully aligned with zero divergence.
+    - **Final workflow state:** 2 active (`compose-and-publish.yml`, `pr-validate.yml`), 11 disabled (`.yml.disabled`), zero untracked.
+    - **No tags touched:** v0.5.0 tag preserved on its original commit.
+    - **Key pattern:** When Squad updates drop enabled `.yml` copies alongside tracked `.disabled` files, always delete the untracked copies — the `.disabled` naming is the disablement mechanism.

--- a/.squad/decisions/inbox/amos-sync-main.md
+++ b/.squad/decisions/inbox/amos-sync-main.md
@@ -1,0 +1,25 @@
+# Decision: Post-release branch sync procedure
+
+**By:** Amos (Platform Engineer)
+**Date:** 2026-04-14
+**Status:** Executed
+
+## Context
+
+After v0.5.0 release (PR #30 merge + tag), dev had 3 post-release doc commits not yet on main. Additionally, 11 untracked enabled Squad workflow files (`.yml`) coexisted with the tracked `.disabled` variants.
+
+## Decision
+
+1. **Squad workflow cleanup:** Delete untracked enabled `.yml` copies; `.disabled` naming is the sole disablement mechanism.
+2. **Branch sync:** Merge `origin/main` into dev (to absorb the release merge commit), PR dev → main (PR #31), then fast-forward dev to main — achieving zero divergence.
+3. **No tags touched:** v0.5.0 remains on its original commit.
+
+## Rationale
+
+- Untracked enabled workflow files would activate Squad automation if accidentally committed — removing them eliminates that risk.
+- Merge-then-PR-then-fast-forward is the cleanest flow when dev and main diverged only via a merge commit.
+- Docs-only changes carry no risk and don't warrant a new release tag.
+
+## Outcome
+
+PR #31 merged. Both branches aligned. Working tree clean.


### PR DESCRIPTION
Fast-forward alignment PR. Single docs-only commit (c8e7644) containing Amos history update and sync decision record from the post-v0.5.0 branch alignment session. No code changes.